### PR TITLE
bugfix for dynamic fk add (new items were not deselectable)

### DIFF
--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -20,7 +20,7 @@ if (jQuery === undefined) {
                 $('#' + id).val(values.join(','));
             }
             recalculate_value();
-            checkboxes.change(recalculate_value);
+            ul.on('change','input[type=checkbox]',recalculate_value);
             ul.sortable({
                 axis: 'y',
                 //containment: 'parent',


### PR DESCRIPTION
When in the admin interface I add an other foreign key, I can see the new item selected. Unfortunately it was unselectable if new. Now it is selectable.
To better express the concept, see the attachments..

![schermata 2014-11-25 alle 15 06 01](https://cloud.githubusercontent.com/assets/2088831/5184159/3d782c36-74b5-11e4-8698-3c5250fed152.png)

![schermata 2014-11-25 alle 15 06 46](https://cloud.githubusercontent.com/assets/2088831/5184158/3d5f8c58-74b5-11e4-9e2a-4568248996a2.png)

N.B. I used jquery "on" method, that is supported only from version Django 1.5 
