### PR TITLE
Fix reading README & CHANGES RST files when the system encoding is not UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,9 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-if sys.version_info[0] < 3:
-    def read(*parts):
-        return codecs.open(os.path.join(os.path.dirname(__file__), *parts)).read()
-
-else:
-    def read(*parts):
-        return open(os.path.join(os.path.dirname(__file__), *parts), 'r').read()
+def read(*parts):
+    return codecs.open(os.path.join(os.path.dirname(__file__), *parts),
+                       encoding='utf8').read()
 
 
 class UltraMagicString(object):

--- a/setup.py
+++ b/setup.py
@@ -21,25 +21,38 @@ def read(*parts):
                        encoding='utf8').read()
 
 
+try:
+    bytes
+except NameError:
+    bytes = str
+
+
 class UltraMagicString(object):
     '''
     Taken from
     http://stackoverflow.com/questions/1162338/whats-the-right-way-to-use-unicode-metadata-in-setup-py
     '''
     def __init__(self, value):
+        if not isinstance(value, bytes):
+            value = value.encode('utf8')
         self.value = value
 
-    def __str__(self):
+    def __bytes__(self):
         return self.value
 
     def __unicode__(self):
         return self.value.decode('UTF-8')
 
+    if sys.version_info[0] < 3:
+        __str__ = __bytes__
+    else:
+        __str__ = __unicode__
+
     def __add__(self, other):
-        return UltraMagicString(self.value + str(other))
+        return UltraMagicString(self.value + bytes(other))
 
     def split(self, *args, **kw):
-        return self.value.split(*args, **kw)
+        return str(self).split(*args, **kw)
 
 
 long_description = UltraMagicString('\n\n'.join((


### PR DESCRIPTION
By default ``open`` in text mode reads files in the [system encoding](https://github.com/python/cpython/blob/6f4d604990c4a22bc06fd044ad61fce331ac9f83/Modules/_io/_iomodule.c#L114), however in this case we know that the encoding of the files being read is UTF-8, regardless of the platform on which the package is being installed.

If this is run on a platform where the default encoding is not UTF-8, the ``setup.py`` call fails because ``CHANGES.rst`` cannot be read in ASCII mode (due to special characters in a contributor's name).

```
Collecting django-sortedm2m==0.9.4 (from -r /app/src/requirements.txt (line 36))
  Downloading django-sortedm2m-0.9.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-7vwuo22m/django-sortedm2m/setup.py", line 51, in <module>
        read('CHANGES.rst'),
      File "/tmp/pip-build-7vwuo22m/django-sortedm2m/setup.py", line 25, in read
        return open(os.path.join(os.path.dirname(__file__), *parts), 'r').read()
      File "/app/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 781: ordinal not in range(128)
    
    ----------------------------------------
     Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-7vwuo22m/django-sortedm2m
```