### PR TITLE
Fixed performance when there is a lot of item in the m2m relation and a visual glitch.

### DIFF
--- a/sortedm2m/static/sortedm2m/widget.css
+++ b/sortedm2m/static/sortedm2m/widget.css
@@ -48,3 +48,7 @@ body.change-form .sortedm2m-container {
     margin: 0;
     padding: 6px 8px;
 }
+
+.hide {
+    display: none;
+}

--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -18,7 +18,7 @@ if (jQuery === undefined) {
                     values.push($(this).val());
                 });
                 $('#' + id).val(values.join(','));
-            }
+            };
             recalculate_value();
             ul.on('change','input[type=checkbox]',recalculate_value);
             ul.sortable({
@@ -30,8 +30,9 @@ if (jQuery === undefined) {
         }
 
         function iterateUl() {
-            $('.sortedm2m').parents('ul').each(function () {
+            $('ul:has(.sortedm2m)').each(function () {
                 prepareUl( $(this) );
+                $(this).removeClass('hide');
             });
         }
 
@@ -51,7 +52,7 @@ if (jQuery === undefined) {
                             $(this).css('display', 'none');
                         } else {
                             $(this).css('display', 'inherit');
-                        };
+                        }
                     });
                 });
             });

--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -4,7 +4,7 @@ if (jQuery === undefined) {
 
 (function ($) {
     $(function () {
-
+        $('.sortedm2m-container').find('ul').addClass('hide');
         function prepareUl(ul) {
             ul.addClass('sortedm2m');
             var checkboxes = ul.find('input[type=checkbox]');

--- a/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
+++ b/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
@@ -6,7 +6,7 @@
         <img src="{% static "sortedm2m/selector-search.gif" %}" alt="" title="{% trans "Type into this box to filter down the list." %}" />
         <input type="text" placeholder="{% trans "Filter" %}" />
     </p>
-    <ul class="hide">
+    <ul>
     {% for row in selected %}
         <li><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
     {% endfor %}

--- a/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
+++ b/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
@@ -1,12 +1,12 @@
 {% load i18n static %}
+
 <div class="sortedm2m-container">
 
     <p class="selector-filter">
         <img src="{% static "sortedm2m/selector-search.gif" %}" alt="" title="{% trans "Type into this box to filter down the list." %}" />
         <input type="text" placeholder="{% trans "Filter" %}" />
     </p>
-
-    <ul>
+    <ul class="hide">
     {% for row in selected %}
         <li><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
     {% endfor %}


### PR DESCRIPTION
Formerly the jQuery code was looping through all the potential `<input>` elements
that could be added to the m2m relationship in order to find the parent
`<ul>` elements. It is now done this other way around, we only loop
through `<ul>` elements that have `<input>` child with the `sortedm2m`
class.

(With this change a page that would take 12sec to load before is now loading instantly.)

We are also hidding the `<ul>` until it gets fully prepared, to avoid to have
a bad flicker when initially loading the page.