### PR TITLE
Made statics work with CachedStaticFilesStorage

### DIFF
--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -4,6 +4,7 @@ import sys
 from itertools import chain
 from django import forms
 from django.conf import settings
+from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.db.models.query import QuerySet
 from django.template.loader import render_to_string
 from django.utils.encoding import force_text
@@ -21,17 +22,14 @@ else:
     str_ = str
 
 
-STATIC_URL = getattr(settings, 'STATIC_URL', settings.MEDIA_URL)
-
-
 class SortedCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
     class Media:
         js = (
-            STATIC_URL + 'sortedm2m/widget.js',
-            STATIC_URL + 'sortedm2m/jquery-ui.js',
+            static('sortedm2m/widget.js'),
+            static('sortedm2m/jquery-ui.js'),
         )
         css = {'screen': (
-            STATIC_URL + 'sortedm2m/widget.css',
+            static('sortedm2m/widget.css'),
         )}
 
     def build_attrs(self, attrs=None, **kwargs):

--- a/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
+++ b/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
@@ -1,4 +1,4 @@
-{% load i18n static %}
+{% load i18n staticfiles %}
 
 <div class="sortedm2m-container">
 


### PR DESCRIPTION
`STATIC_URL` and the `load static` tag doesn't work with CachedStaticFilesStorage.
Only the tag from `load staticfiles` does.

This pull request changes all static file references to use `django.contrib.staticfiles.templatetags.staticfiles`.