### PR TITLE
Fix collapsing filter bar for the new Django 1.9 admin.

### DIFF
--- a/sortedm2m/static/sortedm2m/widget.css
+++ b/sortedm2m/static/sortedm2m/widget.css
@@ -11,7 +11,7 @@
 
 .sortedm2m-container p.selector-filter input {
     width: 532px;
-    margin: 5px 4px;
+    margin: 0 0 0 4px;
 }
 
 ul.sortedm2m {
@@ -46,7 +46,7 @@ body.change-form .sortedm2m-container {
 }
 .module ul.sortedm2m {
     margin: 0;
-    padding: 6px 8px;
+    padding: 10px 0;
 }
 
 .hide {


### PR DESCRIPTION
This PR fixes the collapsing of the filter bar in the default Django 1.9 admin.

Currently:

![screen shot 2015-12-07 at 14 46 49](https://cloud.githubusercontent.com/assets/808271/11628349/690433e4-9cf1-11e5-8b15-8953fccfb661.png)

--

New:

![screen shot 2015-12-07 at 14 35 13](https://cloud.githubusercontent.com/assets/808271/11628359/7b3b9b6a-9cf1-11e5-85ed-1d4fe2cd8cf6.png)