### PR TITLE
Use different function name for dismissing "add" popup when necessary

### DIFF
--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -58,9 +58,15 @@ if (jQuery === undefined) {
             });
         });
 
+        var dismissPopupFnName = 'dismissAddAnotherPopup';
+        // django 1.8+
+        if (window.dismissAddRelatedObjectPopup) {
+            dismissPopupFnName = 'dismissAddRelatedObjectPopup';
+        }
+
         if (window.showAddAnotherPopup) {
-            var django_dismissAddAnotherPopup = window.dismissAddAnotherPopup;
-            window.dismissAddAnotherPopup = function (win, newId, newRepr) {
+            var django_dismissAddAnotherPopup = window[dismissPopupFnName];
+            window[dismissPopupFnName] = function (win, newId, newRepr) {
                 // newId and newRepr are expected to have previously been escaped by
                 // django.utils.html.escape.
                 newId = html_unescape(newId);


### PR DESCRIPTION
Django 1.8 introduced a change of the function name from
`dismissAddAnotherPopup` to `dismissAddRelatedObjectPopup`. Old name was
kept for backwards compatibility, but since it's value is now a
reference and not an actual function, sortedm2m overrides only that
reference and not the actual `dismissAddRelatedObjectPopup` which is
now the function being called in
`django/contrib/admin/templates/admin/popup_response.html`. Since django
no longer calls the overridden function, the added object would only
appear after refresh.

This pull request makes it compatible with django 1.8+.

Ref: https://github.com/django/django/commit/07988744b347302925bc6cc66511e34224db55ab#diff-ec17958cc9f7c2542303557dfc4ad997R130