### PR TITLE
Add support for to_field_name to SortedMultipleChoiceField

### DIFF
--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -105,13 +105,10 @@ class SortedMultipleChoiceField(forms.ModelMultipleChoiceField):
     widget = SortedCheckboxSelectMultiple
 
     def clean(self, value):
-        queryset = super(SortedMultipleChoiceField, self).clean(value)
-        if value is None or not isinstance(queryset, QuerySet):
-            return queryset
-        object_list = dict((
-            (str_(key), value)
-            for key, value in iteritems(queryset.in_bulk(value))))
-        return [object_list[str_(pk)] for pk in value]
+        queryset = super(SortedMultipleChoiceField, self).clean(value)        
+        key = self.to_field_name or 'pk'
+        objects = dict((force_text(getattr(o, key)), o) for o in queryset)
+        return [objects[force_text(val)] for val in value]
 
     if django.VERSION < (1, 8):
         def _has_changed(self, initial, data):

--- a/sortedm2m_tests/test_forms.py
+++ b/sortedm2m_tests/test_forms.py
@@ -15,6 +15,12 @@ class SortedForm(forms.Form):
         required=False)
 
 
+class SortedNameForm(forms.Form):
+    values = SortedMultipleChoiceField(
+        queryset=Book.objects.all(),
+        to_field_name='name')
+
+
 class TestSortedFormField(TestCase):
     def setUp(self):
         self.books = [Book.objects.create(name=c) for c in 'abcdefghik']
@@ -36,6 +42,18 @@ class TestSortedFormField(TestCase):
                 self.books[8]])
 
         form = SortedForm({'values': [book.pk for book in self.books[::-1]]})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(list(form.cleaned_data['values']), self.books[::-1])
+
+    def test_sorted_field_input_with_field_name(self):
+        form = SortedNameForm({'values': ['d', 'b', 'i']})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(list(form.cleaned_data['values']), [
+                self.books[3],
+                self.books[1],
+                self.books[8]])
+
+        form = SortedNameForm({'values': [book.name for book in self.books[::-1]]})
         self.assertTrue(form.is_valid())
         self.assertEqual(list(form.cleaned_data['values']), self.books[::-1])
 


### PR DESCRIPTION
The current implementation depends on `in_bulk`, which requires `value` to be the `pk`, when it can actually be any unique field thanks to the `to_field_name` attribute.

The super implementation handles filtering the queryset, so `clean` only needs to order the objects. This implementation is partially inspired by how the [ModelMultipleChoiceField](https://github.com/django/django/blob/6f5fcfc6d26238810df599b7862d7c6bc0fd303a/django/forms/models.py#L1285) implements it.