### PR TITLE
Fix compatibility with `django-bootstrap3`

### DIFF
--- a/sortedm2m/static/sortedm2m/widget.css
+++ b/sortedm2m/static/sortedm2m/widget.css
@@ -36,7 +36,7 @@ ul.sortedm2m li {
     white-space: pre;
 }
 
-ul.sortedm2m li, ul.sortedm2m label {
+.sortedm2m-item, .sortedm2m label {
     cursor: move;
 }
 

--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -4,7 +4,7 @@ if (jQuery === undefined) {
 
 (function ($) {
     $(function () {
-        $('.sortedm2m-container').find('ul').addClass('hide');
+        $('.sortedm2m-container').find('.sortedm2m-items').addClass('hide');
         function prepareUl(ul) {
             ul.addClass('sortedm2m');
             var checkboxes = ul.find('input[type=checkbox]');
@@ -30,7 +30,7 @@ if (jQuery === undefined) {
         }
 
         function iterateUl() {
-            $('ul:has(.sortedm2m)').each(function () {
+            $('.sortedm2m-items:has(.sortedm2m)').each(function () {
                 prepareUl( $(this) );
                 $(this).removeClass('hide');
             });
@@ -44,7 +44,7 @@ if (jQuery === undefined) {
             $(this).bind('input', function() {
                 var search = $(this).val().toLowerCase();
                 var $el = $(this).closest('.selector-filter');
-                var $container = $el.siblings('ul').each(function() {
+                var $container = $el.siblings('.sortedm2m-items').each(function() {
                     // walk over each child list el and do name comparisons
                     $(this).children().each(function() {
                         var curr = $(this).find('label').text().toLowerCase();
@@ -73,7 +73,7 @@ if (jQuery === undefined) {
                 newRepr = html_unescape(newRepr);
                 var name = windowname_to_id(win.name);
                 var elem = $('#' + name);
-                var sortedm2m = elem.siblings('ul.sortedm2m');
+                var sortedm2m = elem.siblings('.sortedm2m-items.sortedm2m');
                 if (sortedm2m.length == 0) {
                     // no sortedm2m widget, fall back to django's default
                     // behaviour
@@ -87,7 +87,7 @@ if (jQuery === undefined) {
 
                 var id_template = '';
                 var maxid = 0;
-                sortedm2m.find('li input').each(function () {
+                sortedm2m.find('.sortedm2m-item input').each(function () {
                     var match = this.id.match(/^(.+)_(\d+)$/);
                     id_template = match[1];
                     id = parseInt(match[2]);

--- a/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
+++ b/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
@@ -6,13 +6,13 @@
         <img src="{% static "sortedm2m/selector-search.gif" %}" alt="" title="{% trans "Type into this box to filter down the list." %}" />
         <input type="text" placeholder="{% trans "Filter" %}" />
     </p>
-    <ul>
+    <ul class="sortedm2m-items">
     {% for row in selected %}
-        <li><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
+        <li class="sortedm2m-item"><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
     {% endfor %}
 
     {% for row in unselected %}
-        <li><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
+        <li class="sortedm2m-item"><label{{ row.label_for|safe }}>{{ row.rendered_cb }} {{ row.option_label }}</label></li>
     {% endfor %}
     </ul>
 


### PR DESCRIPTION
Fixes issue #78 where drag & drop does not work because `django-bootstrap` replaces `<ul>` and `<li>` tags with `<div>` by operating on classes instead of explicit tag names.