### PR TITLE
Re-adding check for None to clean() (#80)

### DIFF
--- a/sortedm2m/__init__.py
+++ b/sortedm2m/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = '1.3.0.dev1'
+__version__ = '1.3.1'

--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -105,7 +105,9 @@ class SortedMultipleChoiceField(forms.ModelMultipleChoiceField):
     widget = SortedCheckboxSelectMultiple
 
     def clean(self, value):
-        queryset = super(SortedMultipleChoiceField, self).clean(value)        
+        queryset = super(SortedMultipleChoiceField, self).clean(value)
+        if value is None or not isinstance(queryset, QuerySet):
+            return queryset
         key = self.to_field_name or 'pk'
         objects = dict((force_text(getattr(o, key)), o) for o in queryset)
         return [objects[force_text(val)] for val in value]

--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -4,7 +4,6 @@ import sys
 from itertools import chain
 from django import forms
 from django.conf import settings
-from django.db.models.query import QuerySet
 from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 from django.utils.html import conditional_escape, escape
@@ -106,7 +105,7 @@ class SortedMultipleChoiceField(forms.ModelMultipleChoiceField):
 
     def clean(self, value):
         queryset = super(SortedMultipleChoiceField, self).clean(value)
-        if value is None or not isinstance(queryset, QuerySet):
+        if value is None or not hasattr(queryset, '__iter__'):
             return queryset
         key = self.to_field_name or 'pk'
         objects = dict((force_text(getattr(o, key)), o) for o in queryset)


### PR DESCRIPTION
This is basically just the removed check for None and isinstance(queryset, QuerySet) back in place.
If value is None, it can not be iterated and throws an error when handling with pages, articles or any app using this module in Django CMS.

I also bumped the version, to make writing pip requirements easier, like:

> django-sortedm2m!=1.3.0,>=1.2.2

to skip version 1.3.0.dev1.