### PR TITLE
Added back the html_unescape function.

### DIFF
--- a/sortedm2m/static/sortedm2m/widget.js
+++ b/sortedm2m/static/sortedm2m/widget.js
@@ -83,6 +83,16 @@ if (typeof jQuery === 'undefined') {
             dismissPopupFnName = 'dismissAddRelatedObjectPopup';
         }
 
+        function html_unescape(text) {
+            // Unescape a string that was escaped using django.utils.html.escape.
+            text = text.replace(/&lt;/g, '<');
+            text = text.replace(/&gt;/g, '>');
+            text = text.replace(/&quot;/g, '"');
+            text = text.replace(/&#39;/g, "'");
+            text = text.replace(/&amp;/g, '&');
+            return text;
+        }
+
         if (window.showAddAnotherPopup) {
             var django_dismissAddAnotherPopup = window[dismissPopupFnName];
             window[dismissPopupFnName] = function (win, newId, newRepr) {


### PR DESCRIPTION
The html_unescape javascript function, previously present in django's code was removed recently in this commit : https://github.com/django/django/commit/cbaa3ee3ee45d453ab6aa36d57847515dd130b9f
I've added it back locally as it is only used in this part of the code. I have tested it locally on both django 1.8 and django 1.10 using the example code provided in the repository.