### PR TITLE
Prevent Django ManyToManyField from being imported through sortedm2m

### DIFF
--- a/sortedm2m/fields.py
+++ b/sortedm2m/fields.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.db import models
 from django.db.models import signals
 from django.db.models.fields.related import add_lazy_relation
-from django.db.models.fields.related import ManyToManyField
+from django.db.models.fields.related import ManyToManyField as _ManyToManyField
 from django.db.models.fields.related import RECURSIVE_RELATIONSHIP_CONSTANT
 from django.utils import six
 from django.utils.functional import cached_property, curry
@@ -208,7 +208,7 @@ except ImportError:
             )
 
 
-class SortedManyToManyField(ManyToManyField):
+class SortedManyToManyField(_ManyToManyField):
     '''
     Providing a many to many relation that remembers the order of related
     objects.
@@ -250,7 +250,7 @@ class SortedManyToManyField(ManyToManyField):
         if self.rel.symmetrical and (self.rel.to == "self" or self.rel.to == cls._meta.object_name):
             self.rel.related_name = "%s_rel_+" % name
 
-        super(ManyToManyField, self).contribute_to_class(cls, name, **kwargs)
+        super(_ManyToManyField, self).contribute_to_class(cls, name, **kwargs)
 
         # The intermediate m2m model is not auto created if:
         #  1) There is a manually specified intermediate, or

--- a/sortedm2m_tests/test_field.py
+++ b/sortedm2m_tests/test_field.py
@@ -227,3 +227,14 @@ class TestSelfReference(TestCase):
         s1.me.add(s4, s2)
 
         self.assertEqual(list(s1.me.all()), [s3,s4,s2])
+
+
+class TestDjangoManyToManyFieldNotAvailableThroughSortedM2M(TestCase):
+    @staticmethod
+    def _import_django_many_to_many_through_sortedm2m():
+        from sortedm2m.fields import ManyToManyField
+
+    def test_many_to_many_field_not_available(self):
+        self.assertRaises(
+            ImportError,
+            self._import_django_many_to_many_through_sortedm2m)


### PR DESCRIPTION
At my workplace, we recently uncovered a bug (in _our_ codebase) where we had defined a field in `models.py` as a `SortedManyToManyField` but created it in the migration as a `ManyToManyField` (i.e. an unsorted `django.db.models.fields.related.ManyToManyField`), which was inadvertently imported through `sortedm2m` with the following statement:

`from sortedm2m.fields import ManyToManyField`

The author clearly _meant_ to use a `SortedManyToManyField` in the migration - since that would match the model field, and they were importing from `sortedm2m` - but through IDE autocomplete or simple human error, they imported the `ManyToManyField`.

This small change would prevent others making the same error.