### PR TITLE
Made the help text in the footer bold.

### DIFF
--- a/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
+++ b/sortedm2m/templates/sortedm2m/sorted_checkbox_select_multiple_widget.html
@@ -17,7 +17,7 @@
     </ul>
 
     <p class="help">
-        {% trans "Choose items and order by drag & drop." %}
+        <b>{% trans "Choose items and order by drag & drop." %}</b>
     </p>
 
 </div>


### PR DESCRIPTION
The help text "Choose items and order by drag & drop" in the sortedm2m widget is helpful but hard to see. So, making it bolder would help accomplish it.