### PR TITLE
Modified .gitignore to ignore swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pep8.txt
 /dist/
 /.tox/
 /.vagrant/
+*.swp


### PR DESCRIPTION
Many a times, while working on multiple sessions simultaneously .swp files maybe be added my mistake. This PR helps ignoring those files by adding it in gitignore file.