### PR TITLE
Fixes #96: Improve string representation of sortedm2m relationships

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,16 @@ Specifies how the field is called in the intermediate database table by which
 the relationship is ordered. You can change its name if you have a legacy
 database that you need to integrate into your application.
 
+``base_class``
+~~~~~~~~~~~~~~
+
+**Default:** ``None``
+
+You can set the ``base_class``, which is the base class of the through model of
+the sortedm2m relationship between models to an abstract base class containing
+a ``__str__`` method to improve the string representations of sortedm2m
+relationships.
+
 Migrating a ``ManyToManyField`` to be a ``SortedManyToManyField``
 =================================================================
 

--- a/example/testapp/models.py
+++ b/example/testapp/models.py
@@ -17,9 +17,15 @@ class Car(models.Model):
 
 
 @python_2_unicode_compatible
+class BaseCarThrough(object):
+    def __str__(self):
+        return str(self.car) + " in " + str(self.parkingarea)
+
+
+@python_2_unicode_compatible
 class ParkingArea(models.Model):
     name = models.CharField(max_length=50)
-    cars = SortedManyToManyField(Car)
+    cars = SortedManyToManyField(Car, base_class=BaseCarThrough)
 
     def __str__(self):
         return self.name

--- a/sortedm2m_tests/models.py
+++ b/sortedm2m_tests/models.py
@@ -8,8 +8,14 @@ except ImportError:
 from sortedm2m.fields import SortedManyToManyField
 
 
+class BaseBookThrough(object):
+
+    def __str__(self):
+        return "Relationship to {0}".format(self.book.name)
+
+
 class Shelf(models.Model):
-    books = SortedManyToManyField('Book', related_name='shelves')
+    books = SortedManyToManyField('Book', related_name='shelves', base_class=BaseBookThrough)
 
 
 @python_2_unicode_compatible
@@ -23,7 +29,8 @@ class Book(models.Model):
 class DoItYourselfShelf(models.Model):
     books = SortedManyToManyField(Book,
         sort_value_field_name='diy_sort_number',
-        related_name='diy_shelves')
+        related_name='diy_shelves',
+        base_class=BaseBookThrough)
 
 
 class Store(models.Model):

--- a/sortedm2m_tests/test_field.py
+++ b/sortedm2m_tests/test_field.py
@@ -9,7 +9,7 @@ from django.utils import six
 from sortedm2m.compat import get_field, get_rel
 
 from .models import (
-    Book, Shelf, DoItYourselfShelf, Store, MessyStore, SelfReference)
+    Book, Shelf, DoItYourselfShelf, Store, MessyStore, SelfReference, BaseBookThrough)
 
 
 str_ = six.text_type
@@ -190,6 +190,14 @@ class TestSortedManyToManyField(TestCase):
         def get_ids(queryset):
             return [obj.id for obj in queryset]
         self.assertEqual(get_ids(shelf.books.all()), get_ids(books))
+
+    def test_base_class_str(self):
+        shelf = self.model.objects.create()
+        shelf.books.add(self.books[0])
+        through_model = shelf.books.through
+        instance = through_model.objects.all()[0]
+        self.assertEqual(str(instance), "Relationship to {0}".format(instance.book.name))
+
 
 class TestStringReference(TestSortedManyToManyField):
     '''


### PR DESCRIPTION
Fixes #96 

This PR aims to improve the string representation of SortedM2M relationship when deleting one from an admin panel. I basically added a `base_class` parameter, a class which is inherited by the through-model of a sortedm2m relationship. This is basically so that the users of django-sortedm2m can add their own `__unicode__` method and improve the string representation.

For ex., in `example/testapp/models.py` we've passed a base_class argument when a relationship is being established. Check the image below,

![sortedm2m](https://cloud.githubusercontent.com/assets/13820931/24034486/6b08c34a-0b17-11e7-8edb-418cd321ab3c.png)

@gregmuellegger : Please review.