### PR TITLE
adding Django 2.0 test to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     py33-{16,17,18},
     py34-{16,17,18,19,110,111},
     py35-{18,19,110,111},
-    py36-{111,master}
+    py36-{111,20,master}
 
 [testenv]
 commands = python runtests.py
@@ -20,6 +20,7 @@ deps =
     19: Django >= 1.9, < 1.10
     110: Django>=1.10,<1.10.99
     111: Django>=1.11a1,<1.11.99
+    20: Django >= 2.0, <2.1
     master: https://github.com/django/django/tarball/master#egg=Django
     postgres: psycopg2
     mysql: MySQL-python


### PR DESCRIPTION
adding Django 2.0 test to tox.ini for py36. So full compatibility of Django2.0 can be added to django-sortedm2m. This is a part of a gci task:
https://codein.withgoogle.com/dashboard/task-instances/4641906212470784/