### PR TITLE
adding Django 2.0 test to tox.ini and travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
     - { python: 3.5, env: TOXENV=py35-111 }
     - { python: 3.6, env: TOXENV=py36-111 }
     - { python: 3.6, env: TOXENV=py36-master-postgres }
+    - { python: 3.6, env: TOXENV=py36-20 }
   allow_failures:
     - env: TOXENV=py36-master-postgres
 before_install:

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     py33-{16,17,18},
     py34-{16,17,18,19,110,111},
     py35-{18,19,110,111},
-    py36-{111,master}
+    py36-{111,20,master}
 
 [testenv]
 commands = python runtests.py
@@ -20,6 +20,7 @@ deps =
     19: Django >= 1.9, < 1.10
     110: Django>=1.10,<1.10.99
     111: Django>=1.11a1,<1.11.99
+    20: Django>=2.0,<2.1
     master: https://github.com/django/django/tarball/master#egg=Django
     postgres: psycopg2
     mysql: MySQL-python


### PR DESCRIPTION
adding Django 2.0 test to tox.ini and travis tests.adding Django 2.0 test to tox.ini for py36. So full compatibility of Django2.0 can be added to django-sortedm2m. This is a part of a google code in task under @OpenWISP organisation:
https://codein.withgoogle.com/dashboard/task-instances/4641906212470784/


