### PR TITLE
Adding full Django 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
     - { python: 3.5, env: TOXENV=py35-111 }
     - { python: 3.6, env: TOXENV=py36-111 }
     - { python: 3.6, env: TOXENV=py36-master-postgres }
+    - { python: 3.6, env: TOXENV=py36-20 }
   allow_failures:
     - env: TOXENV=py36-master-postgres
 before_install:

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ envlist =
     py26-{15,16},
     {py27,pypy}-{15,16,17,18,19,110,111},
     py33-{16,17,18},
-    py34-{16,17,18,19,110,111},
-    py35-{18,19,110,111},
-    py36-{111,master}
+    py34-{16,17,18,19,110,111,20},
+    py35-{18,19,110,111,20},
+    py36-{111,20,master}
 
 [testenv]
 commands = python runtests.py
@@ -20,6 +20,7 @@ deps =
     19: Django >= 1.9, < 1.10
     110: Django>=1.10,<1.10.99
     111: Django>=1.11a1,<1.11.99
+    20: Django>=2.0,<2.1
     master: https://github.com/django/django/tarball/master#egg=Django
     postgres: psycopg2
     mysql: MySQL-python


### PR DESCRIPTION
From @gandhi23 via https://github.com/gregmuellegger/django-sortedm2m/pull/123

> Adding full django2.0 compatibility by adding django2.0 test to .travis.yml and tox.ini, so full django2.0 is implemented. this is a part of my Google code in task of @openwisp oraganisation. link of google code-in task: https://codein.withgoogle.com/dashboard/task-instances/4641906212470784/



